### PR TITLE
Some more es6 fancyness :)

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -18,7 +18,6 @@
     "quotmark": "single",
     "laxbreak": true,
     "globals"   : {
-        /* MOCHA */
         "describe"   : false,
         "it"         : false,
         "before"     : false,

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
   - '0.10'
+  - '0.12'
+  - 'iojs'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,9 +2,9 @@ var gulp = require('gulp'),
   watch = require('gulp-watch'),
   rename = require('gulp-rename'),
   mocha = require('gulp-mocha'),
-  to5 = require('gulp-6to5');
+  to5 = require('gulp-babel');
 
-gulp.task('6to5', function() {
+gulp.task('babel', function() {
   return gulp.src('**/*.es6')
     .pipe(to5({
       experimental: true,
@@ -16,7 +16,7 @@ gulp.task('6to5', function() {
     .pipe(gulp.dest('./'));
 });
 
-gulp.task('test', ['6to5'], function() {
+gulp.task('test', ['babel'], function() {
   return gulp.src('test.js')
     .pipe(mocha());
 });

--- a/index.es6
+++ b/index.es6
@@ -7,7 +7,7 @@ let left = (array) => slice.call(array, 0, array.length / 2);
 let right = (array) => slice.call(array, array.length / 2);
 
 function merge(leftList, rightList, cmp) {
-  
+
   let sorted = [];
 
   while(leftList.length > 0 && rightList.length > 0) {
@@ -18,16 +18,13 @@ function merge(leftList, rightList, cmp) {
     }
 
   }
-  
-  return sorted.concat(leftList).concat(rightList);
+  return sorted.concat(leftList, rightList);
 }
 
-export default function mergesort(array, cmp) {
+export default function mergesort(array, cmp=comparator) {
 
   let newArray = slice.call(array);
   let leftList, rightList;
-
-  cmp = cmp || comparator;
 
   if (newArray.length <= 1) {
     return newArray;

--- a/index.js
+++ b/index.js
@@ -23,16 +23,16 @@ function merge(leftList, rightList, cmp) {
       sorted.push(rightList.shift());
     }
   }
-
-  return sorted.concat(leftList).concat(rightList);
+  return sorted.concat(leftList, rightList);
 }
 
-function mergesort(array, cmp) {
+function mergesort(array) {
+  var cmp = arguments[1] === undefined ? comparator : arguments[1];
+
+
   var newArray = slice.call(array);
   var leftList = undefined,
       rightList = undefined;
-
-  cmp = cmp || comparator;
 
   if (newArray.length <= 1) {
     return newArray;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
-
 module.exports = mergesort;
+
 var comparator = function (a, b) {
   return a - b;
 };
@@ -14,6 +14,7 @@ var right = function (array) {
 };
 
 function merge(leftList, rightList, cmp) {
+
   var sorted = [];
 
   while (leftList.length > 0 && rightList.length > 0) {
@@ -28,7 +29,6 @@ function merge(leftList, rightList, cmp) {
 
 function mergesort(array) {
   var cmp = arguments[1] === undefined ? comparator : arguments[1];
-
 
   var newArray = slice.call(array);
   var leftList = undefined,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "expect.js": "^0.3.1",
     "gulp": "^3.8.11",
-    "gulp-6to5": "^3.0.0",
+    "gulp-babel": "^4.0.0",
     "gulp-mocha": "^2.0.0",
     "gulp-rename": "^1.2.0",
     "gulp-watch": "^4.1.1",

--- a/test.js
+++ b/test.js
@@ -6,11 +6,8 @@ var mergesort = _interopRequire(require("./index.js"));
 
 var expect = _interopRequire(require("expect.js"));
 
-
-
-
-
 function randomArray(length) {
+
   var result = [];
 
   for (var i = length; i > 0; i -= 1) {
@@ -53,6 +50,7 @@ describe("mergesort", function () {
   });
 
   it("should work with random array", function () {
+
     var array = randomArray(100);
     var sorted = mergesort(array);
 


### PR DESCRIPTION
I also tried to benchmark a bit, the array push part.

I run iojs as my main node executable, but i tried for node 0.12 too.
Results are surprising, but `sorted.push` is faster on iojs and `sorted[i] =` is faster on node.

Should that be changed? as more users are on node still.

``` js
// push_perf.js
var arr1 = [], arr2 = [];

console.time( 'using length' );
for(var i = 0; i < 5000000; ++i) arr1[i] = 0;
console.timeEnd( 'using length' );

console.time( 'using push' );
for(var i = 0; i < 5000000; ++i) arr2.push(0);
console.timeEnd( 'using push' );
```

``` sh
mergesort git/master*
❯ nvm use node
Now using io.js v1.2.0

mergesort git/master*
❯ node push_perf.js
using length: 789ms
using push: 181ms

mergesort git/master*
❯ nvm use node
Now using node v0.12.0

mergesort git/master*
❯ node push_perf.js
using length: 141ms
using push: 275ms
```
